### PR TITLE
Solved n+1 queries problem.

### DIFF
--- a/app/controllers/api/scores_controller.rb
+++ b/app/controllers/api/scores_controller.rb
@@ -5,7 +5,7 @@ module Api
     before_action :validate_score_user_id, only: :destroy
 
     def user_feed
-      scores = Score.all.order(played_at: :desc, id: :desc)
+      scores = Score.all.order(played_at: :desc, id: :desc).includes(:user)
       serialized_scores = scores.map(&:serialize)
 
       response = {


### PR DESCRIPTION
Fixes: https://github.com/GeorgeMarcus/golfr_backend/issues/1

Fixed n+1 queries problem by adopting eager loading.

Changes

Added includes(:user) to make sure the associated user is loaded with score. Because it knows what user needs to be loaded beforehand, it can fetch all users of all requested scores in one query.

Before

(Lazy loading) A select user query is made for each score.

![image](https://user-images.githubusercontent.com/93124356/146391635-9f441304-ec4d-477e-9e0e-5f588448f94c.png)


After

(Eager loading) Only one select query is needed to get users.

![image](https://user-images.githubusercontent.com/93124356/146391691-1f06b462-e917-4b82-ab4b-da7adaa086f6.png)

